### PR TITLE
Fix stray characters in GUI

### DIFF
--- a/backup/gui.py
+++ b/backup/gui.py
@@ -426,4 +426,3 @@ if __name__ == "__main__":
     w   = MainWindow()
     w.show()
     sys.exit(app.exec())
-    a


### PR DESCRIPTION
## Summary
- clean up stray text at end of `backup/gui.py`

## Testing
- `python3 -m py_compile backup/bot_server.py backup/gui.py backup/soundwave.py backup/start_all.py backup/config_dialog.py`

------
https://chatgpt.com/codex/tasks/task_e_683f662527988328a57a2be792303338