### PR TITLE
Fix planning loop name

### DIFF
--- a/LOOPS/loops_BME.txt
+++ b/LOOPS/loops_BME.txt
@@ -4,7 +4,7 @@
   {"name": "BME LOOP",           "can_listen": true,  "can_talk": true},
   {"name": "SCIENCE LOOP",       "can_listen": true,  "can_talk": true},
   {"name": "SYSTEMS LOOP",       "can_listen": true,  "can_talk": true},
-  {"name": "PLANING LOOP",       "can_listen": true,  "can_talk": true},
+  {"name": "PLANNING LOOP",       "can_listen": true,  "can_talk": true},
   {"name": "EVA LOOP",           "can_listen": true,  "can_talk": true},
   {"name": "PR LOOP",            "can_listen": true,  "can_talk": false},
   {"name": "OPS1 LOOP",          "can_listen": true,  "can_talk": true},

--- a/LOOPS/loops_CAPCOM.txt
+++ b/LOOPS/loops_CAPCOM.txt
@@ -4,7 +4,7 @@
   {"name": "BME LOOP",           "can_listen": true,  "can_talk": true},
   {"name": "SCIENCE LOOP",       "can_listen": true,  "can_talk": true},
   {"name": "SYSTEMS LOOP",       "can_listen": true,  "can_talk": true},
-  {"name": "PLANING LOOP",       "can_listen": true,  "can_talk": true},
+  {"name": "PLANNING LOOP",       "can_listen": true,  "can_talk": true},
   {"name": "EVA LOOP",           "can_listen": true,  "can_talk": true},
   {"name": "PR LOOP",            "can_listen": true,  "can_talk": false},
   {"name": "OPS1 LOOP",          "can_listen": true,  "can_talk": true},

--- a/LOOPS/loops_CPOO.txt
+++ b/LOOPS/loops_CPOO.txt
@@ -4,7 +4,7 @@
   {"name": "BME LOOP",           "can_listen": true,  "can_talk": true},
   {"name": "SCIENCE LOOP",       "can_listen": true,  "can_talk": false},
   {"name": "SYSTEMS LOOP",       "can_listen": true,  "can_talk": true},
-  {"name": "PLANING LOOP",       "can_listen": true,  "can_talk": false},
+  {"name": "PLANNING LOOP",       "can_listen": true,  "can_talk": false},
   {"name": "EVA LOOP",           "can_listen": true,  "can_talk": false},
   {"name": "PR LOOP",            "can_listen": true,  "can_talk": false},
   {"name": "OPS1 LOOP",          "can_listen": true,  "can_talk": true},

--- a/LOOPS/loops_EVA.txt
+++ b/LOOPS/loops_EVA.txt
@@ -4,7 +4,7 @@
   {"name": "BME LOOP",           "can_listen": true,  "can_talk": true},
   {"name": "SCIENCE LOOP",       "can_listen": true,  "can_talk": true},
   {"name": "SYSTEMS LOOP",       "can_listen": true,  "can_talk": true},
-  {"name": "PLANING LOOP",       "can_listen": true,  "can_talk": true},
+  {"name": "PLANNING LOOP",       "can_listen": true,  "can_talk": true},
   {"name": "EVA LOOP",           "can_listen": true,  "can_talk": true},
   {"name": "PR LOOP",            "can_listen": true,  "can_talk": false},
   {"name": "OPS1 LOOP",          "can_listen": true,  "can_talk": true},

--- a/LOOPS/loops_FAO.txt
+++ b/LOOPS/loops_FAO.txt
@@ -4,7 +4,7 @@
   {"name": "BME LOOP",           "can_listen": true,  "can_talk": true},
   {"name": "SCIENCE LOOP",       "can_listen": true,  "can_talk": true},
   {"name": "SYSTEMS LOOP",       "can_listen": true,  "can_talk": true},
-  {"name": "PLANING LOOP",       "can_listen": true,  "can_talk": true},
+  {"name": "PLANNING LOOP",       "can_listen": true,  "can_talk": true},
   {"name": "EVA LOOP",           "can_listen": true,  "can_talk": true},
   {"name": "PR LOOP",            "can_listen": true,  "can_talk": false},
   {"name": "OPS1 LOOP",          "can_listen": true,  "can_talk": true},

--- a/LOOPS/loops_FLIGHT.txt
+++ b/LOOPS/loops_FLIGHT.txt
@@ -4,7 +4,7 @@
   {"name": "BME LOOP",           "can_listen": true,  "can_talk": true},
   {"name": "SCIENCE LOOP",       "can_listen": true,  "can_talk": true},
   {"name": "SYSTEMS LOOP",       "can_listen": true,  "can_talk": true},
-  {"name": "PLANING LOOP",       "can_listen": true,  "can_talk": true},
+  {"name": "PLANNING LOOP",       "can_listen": true,  "can_talk": true},
   {"name": "EVA LOOP",           "can_listen": true,  "can_talk": true},
   {"name": "PR LOOP",            "can_listen": true,  "can_talk": false},
   {"name": "OPS1 LOOP",          "can_listen": true,  "can_talk": true},

--- a/LOOPS/loops_SCIENCE.txt
+++ b/LOOPS/loops_SCIENCE.txt
@@ -4,7 +4,7 @@
   {"name": "BME LOOP",           "can_listen": true,  "can_talk": true},
   {"name": "SCIENCE LOOP",       "can_listen": true,  "can_talk": true},
   {"name": "SYSTEMS LOOP",       "can_listen": true,  "can_talk": true},
-  {"name": "PLANING LOOP",       "can_listen": true,  "can_talk": true},
+  {"name": "PLANNING LOOP",       "can_listen": true,  "can_talk": true},
   {"name": "EVA LOOP",           "can_listen": true,  "can_talk": true},
   {"name": "PR LOOP",            "can_listen": true,  "can_talk": false},
   {"name": "OPS1 LOOP",          "can_listen": true,  "can_talk": true},

--- a/backup/LOOPS/loops_BME.txt
+++ b/backup/LOOPS/loops_BME.txt
@@ -4,7 +4,7 @@
   {"name": "BME LOOP",           "can_listen": true,  "can_talk": true},
   {"name": "SCIENCE LOOP",       "can_listen": true,  "can_talk": true},
   {"name": "SYSTEMS LOOP",       "can_listen": true,  "can_talk": true},
-  {"name": "PLANING LOOP",       "can_listen": true,  "can_talk": true},
+  {"name": "PLANNING LOOP",       "can_listen": true,  "can_talk": true},
   {"name": "EVA LOOP",           "can_listen": true,  "can_talk": true},
   {"name": "PR LOOP",            "can_listen": true,  "can_talk": false},
   {"name": "OPS1 LOOP",          "can_listen": true,  "can_talk": true},

--- a/backup/LOOPS/loops_CAPCOM.txt
+++ b/backup/LOOPS/loops_CAPCOM.txt
@@ -4,7 +4,7 @@
   {"name": "BME LOOP",           "can_listen": true,  "can_talk": true},
   {"name": "SCIENCE LOOP",       "can_listen": true,  "can_talk": true},
   {"name": "SYSTEMS LOOP",       "can_listen": true,  "can_talk": true},
-  {"name": "PLANING LOOP",       "can_listen": true,  "can_talk": true},
+  {"name": "PLANNING LOOP",       "can_listen": true,  "can_talk": true},
   {"name": "EVA LOOP",           "can_listen": true,  "can_talk": true},
   {"name": "PR LOOP",            "can_listen": true,  "can_talk": false},
   {"name": "OPS1 LOOP",          "can_listen": true,  "can_talk": true},

--- a/backup/LOOPS/loops_CPOO.txt
+++ b/backup/LOOPS/loops_CPOO.txt
@@ -4,7 +4,7 @@
   {"name": "BME LOOP",           "can_listen": true,  "can_talk": true},
   {"name": "SCIENCE LOOP",       "can_listen": true,  "can_talk": false},
   {"name": "SYSTEMS LOOP",       "can_listen": true,  "can_talk": true},
-  {"name": "PLANING LOOP",       "can_listen": true,  "can_talk": false},
+  {"name": "PLANNING LOOP",       "can_listen": true,  "can_talk": false},
   {"name": "EVA LOOP",           "can_listen": true,  "can_talk": false},
   {"name": "PR LOOP",            "can_listen": true,  "can_talk": false},
   {"name": "OPS1 LOOP",          "can_listen": true,  "can_talk": true},

--- a/backup/LOOPS/loops_EVA.txt
+++ b/backup/LOOPS/loops_EVA.txt
@@ -4,7 +4,7 @@
   {"name": "BME LOOP",           "can_listen": true,  "can_talk": true},
   {"name": "SCIENCE LOOP",       "can_listen": true,  "can_talk": true},
   {"name": "SYSTEMS LOOP",       "can_listen": true,  "can_talk": true},
-  {"name": "PLANING LOOP",       "can_listen": true,  "can_talk": true},
+  {"name": "PLANNING LOOP",       "can_listen": true,  "can_talk": true},
   {"name": "EVA LOOP",           "can_listen": true,  "can_talk": true},
   {"name": "PR LOOP",            "can_listen": true,  "can_talk": false},
   {"name": "OPS1 LOOP",          "can_listen": true,  "can_talk": true},

--- a/backup/LOOPS/loops_FAO.txt
+++ b/backup/LOOPS/loops_FAO.txt
@@ -4,7 +4,7 @@
   {"name": "BME LOOP",           "can_listen": true,  "can_talk": true},
   {"name": "SCIENCE LOOP",       "can_listen": true,  "can_talk": true},
   {"name": "SYSTEMS LOOP",       "can_listen": true,  "can_talk": true},
-  {"name": "PLANING LOOP",       "can_listen": true,  "can_talk": true},
+  {"name": "PLANNING LOOP",       "can_listen": true,  "can_talk": true},
   {"name": "EVA LOOP",           "can_listen": true,  "can_talk": true},
   {"name": "PR LOOP",            "can_listen": true,  "can_talk": false},
   {"name": "OPS1 LOOP",          "can_listen": true,  "can_talk": true},

--- a/backup/LOOPS/loops_FLIGHT.txt
+++ b/backup/LOOPS/loops_FLIGHT.txt
@@ -4,7 +4,7 @@
   {"name": "BME LOOP",           "can_listen": true,  "can_talk": true},
   {"name": "SCIENCE LOOP",       "can_listen": true,  "can_talk": true},
   {"name": "SYSTEMS LOOP",       "can_listen": true,  "can_talk": true},
-  {"name": "PLANING LOOP",       "can_listen": true,  "can_talk": true},
+  {"name": "PLANNING LOOP",       "can_listen": true,  "can_talk": true},
   {"name": "EVA LOOP",           "can_listen": true,  "can_talk": true},
   {"name": "PR LOOP",            "can_listen": true,  "can_talk": false},
   {"name": "OPS1 LOOP",          "can_listen": true,  "can_talk": true},

--- a/backup/LOOPS/loops_SCIENCE.txt
+++ b/backup/LOOPS/loops_SCIENCE.txt
@@ -4,7 +4,7 @@
   {"name": "BME LOOP",           "can_listen": true,  "can_talk": true},
   {"name": "SCIENCE LOOP",       "can_listen": true,  "can_talk": true},
   {"name": "SYSTEMS LOOP",       "can_listen": true,  "can_talk": true},
-  {"name": "PLANING LOOP",       "can_listen": true,  "can_talk": true},
+  {"name": "PLANNING LOOP",       "can_listen": true,  "can_talk": true},
   {"name": "EVA LOOP",           "can_listen": true,  "can_talk": true},
   {"name": "PR LOOP",            "can_listen": true,  "can_talk": false},
   {"name": "OPS1 LOOP",          "can_listen": true,  "can_talk": true},


### PR DESCRIPTION
## Summary
- correct `PLANING LOOP` name to `PLANNING LOOP`
- keep backups in sync

## Testing
- `python3 - <<'PY'
import json, glob
files = glob.glob('LOOPS/*.txt') + glob.glob('backup/LOOPS/*.txt')
for f in files:
    with open(f) as fp:
        json.load(fp)
print('JSON files OK')
PY`

------
https://chatgpt.com/codex/tasks/task_e_683f68dedf108328a7e266130185a4a4